### PR TITLE
feat : 만다르트 태그 관련 기능 추가(생성, 삭제, 조회)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.projectreactor:reactor-test")
+    testImplementation("com.h2database:h2")
 
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
 

--- a/src/main/kotlin/com/mandamong/server/common/constants/ApiPath.kt
+++ b/src/main/kotlin/com/mandamong/server/common/constants/ApiPath.kt
@@ -46,4 +46,13 @@ object ApiPath {
     object Action {
         const val UPDATE = "/api/mandalart/action/{actionId}"
     }
+
+    object Tag {
+        const val CREATE = "/api/tag"
+        const val DELETE = "/api/tag/{tagId}"
+        const val TAGS = "/api/tag"
+        const val SEARCH = "/api/tag/search"
+        const val ADD_TO_MANDALART = "/api/mandalart/{mandalartId}/tag"
+        const val REMOVE_FROM_MANDALART = "/api/mandalart/{mandalartId}/tag/{tagId}"
+    }
 }

--- a/src/main/kotlin/com/mandamong/server/mandalart/controller/TagController.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/controller/TagController.kt
@@ -1,0 +1,82 @@
+package com.mandamong.server.mandalart.controller
+
+import com.mandamong.server.common.constants.ApiPath
+import com.mandamong.server.common.dto.ApiResponse
+import com.mandamong.server.mandalart.dto.AddTagToMandalartRequest
+import com.mandamong.server.mandalart.dto.CreateTagRequest
+import com.mandamong.server.mandalart.dto.TagResponse
+import com.mandamong.server.mandalart.service.MandalartTagService
+import com.mandamong.server.mandalart.service.TagService
+import com.mandamong.server.user.dto.LoginUser
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class TagController(
+    private val tagService: TagService,
+    private val mandalartTagService: MandalartTagService,
+) {
+    @PostMapping(ApiPath.Tag.CREATE)
+    fun createTag(
+        @RequestBody request: CreateTagRequest,
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<TagResponse>> {
+        val tag = tagService.create(request.name, loginUser.userId)
+        return ApiResponse.created(TagResponse.from(tag))
+    }
+
+    @DeleteMapping(ApiPath.Tag.DELETE)
+    fun deleteTag(
+        @PathVariable tagId: Long,
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        tagService.delete(tagId, loginUser.userId)
+        return ApiResponse.deleted()
+    }
+
+    @GetMapping(ApiPath.Tag.TAGS)
+    fun getTags(
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<List<TagResponse>>> {
+        val tags = tagService.findByUser(loginUser.userId)
+        val tagResponses = tags.map { TagResponse.from(it) }
+        return ApiResponse.ok(tagResponses)
+    }
+
+    @GetMapping(ApiPath.Tag.SEARCH)
+    fun searchTags(
+        @RequestParam keyword: String,
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<List<TagResponse>>> {
+        val tags = tagService.searchByName(loginUser.userId, keyword)
+        val tagResponses = tags.map { TagResponse.from(it) }
+        return ApiResponse.ok(tagResponses)
+    }
+
+    @PostMapping(ApiPath.Tag.ADD_TO_MANDALART)
+    fun addTagToMandalart(
+        @PathVariable mandalartId: Long,
+        @RequestBody request: AddTagToMandalartRequest,
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        mandalartTagService.addTagToMandalart(mandalartId, request.tagId, loginUser.userId)
+        return ApiResponse.ok()
+    }
+
+    @DeleteMapping(ApiPath.Tag.REMOVE_FROM_MANDALART)
+    fun removeTagFromMandalart(
+        @PathVariable mandalartId: Long,
+        @PathVariable tagId: Long,
+        @AuthenticationPrincipal loginUser: LoginUser,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        mandalartTagService.removeTagFromMandalart(mandalartId, tagId, loginUser.userId)
+        return ApiResponse.ok()
+    }
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/dto/AddTagToMandalartRequest.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/dto/AddTagToMandalartRequest.kt
@@ -1,0 +1,5 @@
+package com.mandamong.server.mandalart.dto
+
+data class AddTagToMandalartRequest(
+    val tagId: Long,
+)

--- a/src/main/kotlin/com/mandamong/server/mandalart/dto/CreateTagRequest.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/dto/CreateTagRequest.kt
@@ -1,0 +1,13 @@
+package com.mandamong.server.mandalart.dto
+
+import com.mandamong.server.mandalart.entity.Tag
+import com.mandamong.server.user.entity.User
+
+data class CreateTagRequest(
+    val name: String,
+) {
+    fun toEntity(user: User): Tag = Tag.of(
+        name = name,
+        user = user,
+    )
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/dto/TagResponse.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/dto/TagResponse.kt
@@ -1,0 +1,20 @@
+package com.mandamong.server.mandalart.dto
+
+import com.mandamong.server.mandalart.entity.Tag
+import java.time.LocalDateTime
+
+data class TagResponse(
+    val id: Long,
+    val name: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(tag: Tag): TagResponse = TagResponse(
+            id = tag.id,
+            name = tag.name,
+            createdAt = tag.createdAt,
+            updatedAt = tag.updatedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/entity/MandalartTag.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/entity/MandalartTag.kt
@@ -1,0 +1,45 @@
+package com.mandamong.server.mandalart.entity
+
+import com.mandamong.server.common.entity.BaseTimeEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(
+    name = "mandalart_tags",
+    indexes = [
+        Index(name = "mandalart_tags_mandalart_id_index", columnList = "mandalart_id"),
+        Index(name = "mandalart_tags_tag_id_index", columnList = "tag_id"),
+        Index(name = "mandalart_tags_unique_index", columnList = "mandalart_id, tag_id", unique = true)
+    ]
+)
+class MandalartTag(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @JoinColumn(name = "mandalart_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    val mandalart: Mandalart,
+    @JoinColumn(name = "tag_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    val tag: Tag,
+) : BaseTimeEntity() {
+    
+    companion object {
+        fun of(
+            mandalart: Mandalart,
+            tag: Tag,
+        ): MandalartTag = MandalartTag(
+            mandalart = mandalart,
+            tag = tag,
+        )
+    }
+    
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/entity/Tag.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/entity/Tag.kt
@@ -1,13 +1,10 @@
 package com.mandamong.server.mandalart.entity
 
 import com.mandamong.server.common.entity.BaseTimeEntity
-import com.mandamong.server.mandalart.enums.Status
 import com.mandamong.server.user.entity.User
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -16,27 +13,37 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 
 @Entity
-@Table(name = "mandalarts", indexes = [Index(name = "mandalarts_user_id_index", columnList = "user_id")])
-class Mandalart(
+@Table(
+    name = "tags", 
+    indexes = [
+        Index(name = "tags_user_id_index", columnList = "user_id"),
+        Index(name = "tags_name_user_id_index", columnList = "name, user_id", unique = true)
+    ]
+)
+class Tag(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @Column(name = "name")
+    @Column(name = "name", nullable = false, length = 50)
     var name: String,
     @JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
     val user: User,
-    @Column(name = "status", nullable = false)
-    @Enumerated(EnumType.STRING)
-    var status: Status = Status.IN_PROGRESS,
-    @OneToOne(mappedBy = "mandalart", cascade = [CascadeType.REMOVE], orphanRemoval = true, fetch = FetchType.LAZY)
-    val subject: Subject? = null,
-    @OneToMany(mappedBy = "mandalart", cascade = [CascadeType.REMOVE], orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "tag", cascade = [CascadeType.REMOVE], orphanRemoval = true, fetch = FetchType.LAZY)
     val mandalartTags: MutableList<MandalartTag> = mutableListOf(),
 ) : BaseTimeEntity() {
+    
+    companion object {
+        fun of(
+            name: String,
+            user: User,
+        ): Tag = Tag(
+            name = name,
+            user = user,
+        )
+    }
     
 }

--- a/src/main/kotlin/com/mandamong/server/mandalart/repository/MandalartTagRepository.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/repository/MandalartTagRepository.kt
@@ -1,0 +1,23 @@
+package com.mandamong.server.mandalart.repository
+
+import com.mandamong.server.mandalart.entity.Mandalart
+import com.mandamong.server.mandalart.entity.MandalartTag
+import com.mandamong.server.mandalart.entity.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MandalartTagRepository : JpaRepository<MandalartTag, Long> {
+    
+    fun existsByMandalartAndTag(mandalart: Mandalart, tag: Tag): Boolean
+    
+    @Modifying
+    @Query("""
+        DELETE FROM MandalartTag mt 
+        WHERE mt.mandalart.id = :mandalartId AND mt.tag.id = :tagId
+    """)
+    fun deleteByMandalartIdAndTagId(@Param("mandalartId") mandalartId: Long, @Param("tagId") tagId: Long)
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/repository/TagRepository.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/repository/TagRepository.kt
@@ -1,0 +1,22 @@
+package com.mandamong.server.mandalart.repository
+
+import com.mandamong.server.mandalart.entity.Tag
+import com.mandamong.server.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TagRepository : JpaRepository<Tag, Long> {
+    
+    fun findByUserOrderByCreatedAtDesc(user: User): List<Tag>
+    
+    @Query("""
+        SELECT t FROM Tag t 
+        WHERE t.user = :user 
+        AND t.name LIKE %:keyword% 
+        ORDER BY t.createdAt DESC
+    """)
+    fun findByUserAndNameContaining(@Param("user") user: User, @Param("keyword") keyword: String): List<Tag>
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/service/MandalartTagService.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/service/MandalartTagService.kt
@@ -1,0 +1,76 @@
+package com.mandamong.server.mandalart.service
+
+import com.mandamong.server.common.error.exception.UnauthorizedException
+import com.mandamong.server.common.util.log.log
+import com.mandamong.server.mandalart.entity.MandalartTag
+import com.mandamong.server.mandalart.repository.MandalartTagRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MandalartTagService(
+    private val mandalartTagRepository: MandalartTagRepository,
+    private val mandalartService: MandalartService,
+    private val tagService: TagService,
+) {
+    private val log = log()
+
+    @Transactional
+    fun addTagToMandalart(
+        mandalartId: Long,
+        tagId: Long,
+        userId: Long,
+    ): MandalartTag {
+        val mandalart = mandalartService.getById(mandalartId)
+        val tag = tagService.getById(tagId)
+        
+        // 소유권 검증
+        validateMandalartOwnership(mandalart.user.id, userId)
+        validateTagOwnership(tag.user.id, userId)
+        
+        // 이미 연결되어 있는지 확인
+        if (mandalartTagRepository.existsByMandalartAndTag(mandalart, tag)) {
+            throw IllegalArgumentException("Tag is already added to mandalart")
+        }
+        
+        val mandalartTag = MandalartTag.of(mandalart, tag)
+        val savedMandalartTag = mandalartTagRepository.save(mandalartTag)
+        log.info("ADD_TAG_TO_MANDALART mandalartId=$mandalartId tagId=$tagId userId=$userId")
+        return savedMandalartTag
+    }
+
+    @Transactional
+    fun removeTagFromMandalart(
+        mandalartId: Long,
+        tagId: Long,
+        userId: Long,
+    ) {
+        val mandalart = mandalartService.getById(mandalartId)
+        val tag = tagService.getById(tagId)
+        
+        // 소유권 검증
+        validateMandalartOwnership(mandalart.user.id, userId)
+        validateTagOwnership(tag.user.id, userId)
+        
+        mandalartTagRepository.deleteByMandalartIdAndTagId(mandalartId, tagId)
+        log.info("REMOVE_TAG_FROM_MANDALART mandalartId=$mandalartId tagId=$tagId userId=$userId")
+    }
+
+    private fun validateMandalartOwnership(
+        mandalartOwnerId: Long,
+        userId: Long,
+    ) {
+        if (mandalartOwnerId != userId) {
+            throw UnauthorizedException(message = "Mandalart does not belong to user")
+        }
+    }
+
+    private fun validateTagOwnership(
+        tagOwnerId: Long,
+        userId: Long,
+    ) {
+        if (tagOwnerId != userId) {
+            throw UnauthorizedException(message = "Tag does not belong to user")
+        }
+    }
+}

--- a/src/main/kotlin/com/mandamong/server/mandalart/service/TagService.kt
+++ b/src/main/kotlin/com/mandamong/server/mandalart/service/TagService.kt
@@ -1,0 +1,73 @@
+package com.mandamong.server.mandalart.service
+
+import com.mandamong.server.common.error.exception.IdNotFoundException
+import com.mandamong.server.common.error.exception.UnauthorizedException
+import com.mandamong.server.common.util.log.log
+import com.mandamong.server.mandalart.entity.Tag
+import com.mandamong.server.mandalart.repository.TagRepository
+import com.mandamong.server.user.entity.User
+import com.mandamong.server.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Service
+class TagService(
+    private val tagRepository: TagRepository,
+    private val userService: UserService,
+) {
+    private val log = log()
+
+    @Transactional
+    fun create(
+        name: String,
+        userId: Long,
+    ): Tag {
+        val user: User = userService.getById(userId)
+        val tag = Tag.of(name = name, user = user)
+        val savedTag = tagRepository.save(tag)
+        log.info("CREATE_TAG tagId=${savedTag.id} userId=$userId name=$name")
+        return savedTag
+    }
+
+    @Transactional
+    fun delete(
+        tagId: Long,
+        userId: Long,
+    ) {
+        val tag = getById(tagId)
+        validateTagOwnership(tag, userId)
+        tagRepository.deleteById(tagId)
+        log.info("DELETE_TAG tagId=$tagId userId=$userId")
+    }
+
+    @Transactional(readOnly = true)
+    fun findById(id: Long): Tag? = tagRepository.findById(id).getOrNull()
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Tag = findById(id) ?: throw IdNotFoundException(id)
+
+    @Transactional(readOnly = true)
+    fun findByUser(userId: Long): List<Tag> {
+        val user = userService.getById(userId)
+        return tagRepository.findByUserOrderByCreatedAtDesc(user)
+    }
+
+    @Transactional(readOnly = true)
+    fun searchByName(
+        userId: Long,
+        keyword: String,
+    ): List<Tag> {
+        val user = userService.getById(userId)
+        return tagRepository.findByUserAndNameContaining(user, keyword)
+    }
+
+    private fun validateTagOwnership(
+        tag: Tag,
+        userId: Long,
+    ) {
+        if (tag.user.id != userId) {
+            throw UnauthorizedException(message = "Tag does not belong to user")
+        }
+    }
+}

--- a/src/test/kotlin/com/mandamong/server/config/TestConfig.kt
+++ b/src/test/kotlin/com/mandamong/server/config/TestConfig.kt
@@ -1,0 +1,19 @@
+package com.mandamong.server.config
+
+import com.mandamong.server.infrastructure.minio.service.MinioService
+import org.mockito.Mockito
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@TestConfiguration
+@Profile("test")
+class TestConfig {
+
+    @Bean
+    @Primary
+    fun minioService(): MinioService {
+        return Mockito.mock(MinioService::class.java)
+    }
+}

--- a/src/test/kotlin/com/mandamong/server/config/WithMockLoginUser.kt
+++ b/src/test/kotlin/com/mandamong/server/config/WithMockLoginUser.kt
@@ -1,0 +1,9 @@
+package com.mandamong.server.config
+
+import org.springframework.security.test.context.support.WithSecurityContext
+
+@Retention(AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithMockLoginUserSecurityContextFactory::class)
+annotation class WithMockLoginUser(
+    val userId: Long = 1L
+)

--- a/src/test/kotlin/com/mandamong/server/config/WithMockLoginUserSecurityContextFactory.kt
+++ b/src/test/kotlin/com/mandamong/server/config/WithMockLoginUserSecurityContextFactory.kt
@@ -1,0 +1,19 @@
+package com.mandamong.server.config
+
+import com.mandamong.server.user.dto.LoginUser
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+class WithMockLoginUserSecurityContextFactory : WithSecurityContextFactory<WithMockLoginUser> {
+    
+    override fun createSecurityContext(annotation: WithMockLoginUser): SecurityContext {
+        val principal = LoginUser(userId = annotation.userId)
+        val authentication = UsernamePasswordAuthenticationToken(principal, null, emptyList())
+        
+        val context = SecurityContextHolder.createEmptyContext()
+        context.authentication = authentication
+        return context
+    }
+}

--- a/src/test/kotlin/com/mandamong/server/mandalart/controller/TagControllerTest.kt
+++ b/src/test/kotlin/com/mandamong/server/mandalart/controller/TagControllerTest.kt
@@ -1,0 +1,227 @@
+package com.mandamong.server.mandalart.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mandamong.server.mandalart.dto.AddTagToMandalartRequest
+import com.mandamong.server.mandalart.dto.CreateTagRequest
+import com.mandamong.server.mandalart.entity.Mandalart
+import com.mandamong.server.mandalart.entity.Tag
+import com.mandamong.server.mandalart.repository.MandalartRepository
+import com.mandamong.server.mandalart.repository.MandalartTagRepository
+import com.mandamong.server.mandalart.repository.TagRepository
+import com.mandamong.server.user.entity.User
+import com.mandamong.server.user.model.Email
+import com.mandamong.server.user.repository.UserRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import com.mandamong.server.config.TestConfig
+import org.springframework.http.MediaType
+import com.mandamong.server.user.dto.LoginUser
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import jakarta.persistence.EntityManager
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestConfig::class)
+@ActiveProfiles("test") 
+@Transactional
+class TagControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var tagRepository: TagRepository
+
+    @Autowired
+    private lateinit var mandalartRepository: MandalartRepository
+
+    @Autowired
+    private lateinit var mandalartTagRepository: MandalartTagRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    private lateinit var testUser: User
+    private lateinit var testMandalart: Mandalart
+
+    @BeforeEach
+    fun setUp() {
+        // 테스트 사용자 생성
+        testUser = User(
+            email = Email.from("test@example.com"),
+            nickname = "testUser",
+            password = "encodedPassword",
+            language = "ko"
+        )
+        userRepository.save(testUser)
+
+        // 테스트 만다라트 생성
+        testMandalart = Mandalart(
+            name = "테스트 만다라트",
+            user = testUser
+        )
+        mandalartRepository.save(testMandalart)
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        SecurityContextHolder.clearContext()
+        // 네이티브 쿼리로 순서대로 삭제
+        entityManager.createNativeQuery("DELETE FROM mandalart_tags").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM mandalarts").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM tags").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM users").executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+    }
+    
+    private fun setAuthentication(userId: Long) {
+        val loginUser = LoginUser(userId)
+        val authentication = UsernamePasswordAuthenticationToken(loginUser, null, emptyList())
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+        @DisplayName("태그 생성 - 성공")
+    fun createTag_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val request = CreateTagRequest(name = "운동")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/tag")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.payload.name").value("운동"))
+            .andExpect(jsonPath("$.payload.id").exists())
+    }
+
+    @Test
+    @DisplayName("태그 삭제 - 성공")
+    fun deleteTag_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val tag = Tag.of(name = "삭제할태그", user = testUser)
+        tagRepository.save(tag)
+
+        // when & then
+        mockMvc.perform(
+            delete("/api/tag/{tagId}", tag.id)
+        )
+            .andExpect(status().isNoContent)
+    }
+
+
+    @Test
+    @DisplayName("사용자 태그 목록 조회 - 성공")
+    fun getTags_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val tag1 = Tag.of(name = "운동", user = testUser)
+        val tag2 = Tag.of(name = "독서", user = testUser)
+        tagRepository.saveAll(listOf(tag1, tag2))
+
+        // when & then
+        mockMvc.perform(
+            get("/api/tag")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.payload").isArray)
+            .andExpect(jsonPath("$.payload.length()").value(2))
+            .andExpect(jsonPath("$.payload[0].name").exists())
+            .andExpect(jsonPath("$.payload[1].name").exists())
+    }
+
+    @Test
+    @DisplayName("태그 검색 - 성공")
+    fun searchTags_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val tag1 = Tag.of(name = "운동하기", user = testUser)
+        val tag2 = Tag.of(name = "독서하기", user = testUser)
+        val tag3 = Tag.of(name = "운동계획", user = testUser)
+        tagRepository.saveAll(listOf(tag1, tag2, tag3))
+
+        // when & then - "운동" 키워드로 검색
+        mockMvc.perform(
+            get("/api/tag/search")
+                .param("keyword", "운동")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.payload").isArray)
+            .andExpect(jsonPath("$.payload.length()").value(2))
+    }
+
+    @Test
+    @DisplayName("만다라트에 태그 추가 - 성공")
+    fun addTagToMandalart_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val tag = Tag.of(name = "목표", user = testUser)
+        tagRepository.save(tag)
+
+        val request = AddTagToMandalartRequest(tagId = tag.id)
+
+        // when & then
+        mockMvc.perform(
+            post("/api/mandalart/{mandalartId}/tag", testMandalart.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+    }
+
+
+    @Test
+    @DisplayName("만다라트에서 태그 제거 - 성공")
+    fun removeTagFromMandalart_Success() {
+        // given
+        setAuthentication(testUser.id)
+        val tag = Tag.of(name = "제거할태그", user = testUser)
+        tagRepository.save(tag)
+
+        // 먼저 태그를 추가
+        val request = AddTagToMandalartRequest(tagId = tag.id)
+        mockMvc.perform(
+            post("/api/mandalart/{mandalartId}/tag", testMandalart.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+
+        // when & then - 태그 제거
+        mockMvc.perform(
+            delete("/api/mandalart/{mandalartId}/tag/{tagId}", testMandalart.id, tag.id)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+    }
+
+}


### PR DESCRIPTION
만다르트 태그 기능 추가
- 유저 별로 태그를 관리하도록 entity 구성
- 유저별로 같은 태그로 만다르트에 태깅할 수 있도록 구현

추가로 생각해볼 점
- 태그값을 굳이 유저별로 할 필요가 있을까? 차라리 태그는 글로벌하게 재사용하도록 만들면 되지 않을까? 다른 사람 의견이 궁금
- 인증/인가 및 데이터들이 복잡하게 연결되어 있어서 테스트가 너무 어려워 통합 테스트 로직이 필요할 것으로 보임 -> 이거 환경을 지금 구성안하면 개발 속도 및 테스트 속도가 현저하게 느려질 것

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 태그 생성·삭제·목록·검색 기능 추가
  - 만달아트에 태그 추가/해제 기능 제공
  - 모든 엔드포인트가 인증된 사용자 기준으로 동작하며 표준 응답 형식 적용

- Tests
  - 태그 관련 엔드투엔드/통합 테스트 추가로 주요 시나리오(생성, 삭제, 조회, 검색, 연결/해제) 검증

- Chores
  - 테스트용 인메모리 DB 의존성 및 프로파일 설정 추가
  - 테스트 환경에서 외부 스토리지 서비스 목(mock) 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->