### PR TITLE
TokenUtil 단위 테스트 수정

### DIFF
--- a/src/test/kotlin/com/mandamong/server/common/util/jwt/TokenUtilTest.kt
+++ b/src/test/kotlin/com/mandamong/server/common/util/jwt/TokenUtilTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import java.util.Date
 
 class TokenUtilTest {
-    private val properties: TokenProperties = TokenProperties(issuer = ISSUER, secret = SECRET, expiry = EXPIRY)
+    private val properties = TokenProperties(issuer = ISSUER, secret = SECRET, expiry = EXPIRY)
     private val tokenUtil = TokenUtil(properties)
 
     @Test
@@ -32,7 +32,7 @@ class TokenUtilTest {
     companion object {
         private const val USER_ID = 1L
         private const val ISSUER = "test-issuer"
-        private const val SECRET = "secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret"
+        private const val SECRET = "c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0"
         private val EXPIRY = TokenProperties.Expiry(access = 3600, refresh = 7200)
     }
 }

--- a/src/test/kotlin/com/mandamong/server/common/util/jwt/TokenUtilTest.kt
+++ b/src/test/kotlin/com/mandamong/server/common/util/jwt/TokenUtilTest.kt
@@ -3,34 +3,36 @@ package com.mandamong.server.common.util.jwt
 import io.jsonwebtoken.Claims
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import java.util.Date
 
-@SpringBootTest
 class TokenUtilTest {
-    @Autowired
-    private lateinit var tokenUtil: TokenUtil
-
-    private val memberId = 1L
+    private val properties: TokenProperties = TokenProperties(issuer = ISSUER, secret = SECRET, expiry = EXPIRY)
+    private val tokenUtil = TokenUtil(properties)
 
     @Test
     fun `AccessToken 발급에 성공한다`() {
-        val accessToken = tokenUtil.createAccessToken(memberId)
+        val accessToken = tokenUtil.createAccessToken(USER_ID)
         val claims: Claims = tokenUtil.parseAccessToken(accessToken)
 
         assertThat(accessToken).isNotNull()
-        assertThat(claims.subject).isEqualTo(memberId.toString())
+        assertThat(claims.subject).isEqualTo(USER_ID.toString())
         assertThat(claims.expiration).isAfter(Date())
     }
 
     @Test
     fun `RefreshToken 발급에 성공한다`() {
-        val refreshToken = tokenUtil.createRefreshToken(memberId)
+        val refreshToken = tokenUtil.createRefreshToken(USER_ID)
         val claims: Claims = tokenUtil.parseRefreshToken(refreshToken)
 
         assertThat(refreshToken).isNotNull()
-        assertThat(claims.subject).isEqualTo(memberId.toString())
+        assertThat(claims.subject).isEqualTo(USER_ID.toString())
         assertThat(claims.expiration).isAfter(Date())
+    }
+
+    companion object {
+        private const val USER_ID = 1L
+        private const val ISSUER = "test-issuer"
+        private const val SECRET = "secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret"
+        private val EXPIRY = TokenProperties.Expiry(access = 3600, refresh = 7200)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 스프링 부트 테스트 컨텍스트 의존을 제거하고 단위 테스트로 전환해 실행 속도·안정성 향상.
  * 테스트가 자체 구성된 토큰 설정(발급자·비밀·만료 등)과 상수화된 사용자 ID를 사용하도록 변경.
  * 토큰 생성·검증 시 주장의 대상(subject) 비교를 명확히 해 실패 원인 추적성 개선.
  * 외부 의존성 감소로 유지보수성 및 재현성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->